### PR TITLE
Fixed #3 Grammar analyze and pamela disagree

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,9 +19,9 @@
             :url "http://opensource.org/licenses/Apache-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  ;; logging
-                 [com.taoensso/timbre "4.3.1"]
+                 [com.taoensso/timbre "4.4.0-alpha1"]
                  [org.slf4j/slf4j-api "1.7.21"]
-                 [com.fzakaria/slf4j-timbre "0.3.1"]
+                 [com.fzakaria/slf4j-timbre "0.3.2"]
                  [avenir "0.2.1"]
                  [org.clojure/tools.logging "0.3.1"
                   :exclusions [org.clojure/clojure]]
@@ -32,7 +32,7 @@
                  [riddley "0.1.12"]
                  [environ "1.0.3"]
                  ;; required for elastich
-                 [clj-http "2.1.0"]
+                 [clj-http "3.1.0"]
                  [clojurewerkz/elastisch "2.2.1" :exclusions [clj-http]]
                  [aleph "0.4.2-alpha4"]
                  [clj-time "0.11.0"]
@@ -41,9 +41,9 @@
                  [compojure "1.5.0" :exclusions [commons-codec]]
                  [enlive "1.1.6"]
                  [org.clojure/data.json "0.2.6"]
-                 [cljsjs/react-dom-server "15.0.2-0"]  ;; for sablono
-                 [cljsjs/react-dom "15.0.2-0"] ;; for sablono
-                 [org.omcljs/om "1.0.0-alpha34"]
+                 [cljsjs/react-dom-server "15.1.0-0"]  ;; for sablono
+                 [cljsjs/react-dom "15.1.0-0"] ;; for sablono
+                 [org.omcljs/om "1.0.0-alpha36"]
                  [sablono "0.7.1"]
                  [cljs-http "0.1.40"]
                  ;; the following are to resolve dependency conflicts

--- a/src/main/clj/pamela/pclass.clj
+++ b/src/main/clj/pamela/pclass.clj
@@ -974,9 +974,13 @@
   **body** is the method body which may either be :primitive
   for primitive methods or comprised of PAMELA functions."
   {:added "0.2.0" :doc/format :markdown}
-  [name conds args & body-betweens]
+  [name conds & args-body-betweens]
   (validate-name name)
-  (let [body (first body-betweens)
+  (let [[conds args body-betweens]
+        (if (vector? conds)
+          [{} conds args-body-betweens]
+          [conds (first args-body-betweens) (rest args-body-betweens)])
+        body (first body-betweens)
         b (:betweens (prepare-betweens (rest body-betweens)))
         safe-body (restore-pamela-args (replace-pamela-calls body))
         argstrs (mapv str args)]

--- a/src/test/pamela/sequence.infeasible.pamela
+++ b/src/test/pamela/sequence.infeasible.pamela
@@ -1,3 +1,16 @@
+;; Copyright © 2016 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+;; Acknowledgement and Disclaimer:
+;; This material is based upon work supported by the Army Contracting
+;; and DARPA under contract No. W911NF-15-C-0005.
+;; Any opinions, findings and conclusions or recommendations expressed
+;; in this material are those of the author(s) and do necessarily reflect the
+;; views of the Army Contracting Command and DARPA.
+
 ;; An infeasible sequence of few activities
 
 (defpclass plant []


### PR DESCRIPTION
For defpmethod the grammar says the condition map is optional:
  defpmethod = <LP> <DEFPMETHOD> symbol cond-map? args fn? between-stmt* <RP>
...but the implementation assumed it was always present.

Also
- Updated dependencies
- Fixed missing copyright header on new example PAMELA file

Signed-off-by: Tom Marble <tmarble@info9.net>