### PR TITLE
Improved Logging

### DIFF
--- a/bin/cli-test
+++ b/bin/cli-test
@@ -23,7 +23,8 @@ code="$(pwd -P)"
 
 cd "src/test/cli"
 
-export PATH=${PATH}:"$code/bin"
+# ensure the pamela script we use is from this directory
+export PATH="$code/bin":${PATH}
 export CODE="$code"
 export RESULTS="$code/target/cli-test"
 

--- a/bin/pamela
+++ b/bin/pamela
@@ -27,6 +27,7 @@ cd ..
 # top="$(pwd -P)"
 top="."
 logs="$top/logs"
+rc=0
 
 if [ ! -d "$logs" ]; then
     mkdir "$logs"
@@ -50,7 +51,7 @@ fi
 unset PAGER
 
 verbose=$PAMELA_VERBOSE
-logfile="$logs/$program.log"
+# logfile="$logs/$program-script.log"
 errfile="$logs/${program}-errors.log"
 target="$top/target"
 jar="$target/uberjar/$program.jar"
@@ -104,7 +105,7 @@ leinargs="run --"
 
 usage() {
     if [ -z "$PAMELAD" ]; then
-        err "invalid command line"
+        err "invalid command line (type 'pamela -h' for usage)"
     else
         curl -s -XPOST $url -F 001=select -F 001.s=--help
     fi
@@ -124,11 +125,11 @@ while [ $# -gt 0 ]; do
             leinargs="$leinargs $1"
             verbose=$(( $verbose + 1 ))
             ;;
-        (-h|--help|-V|--version|-r|--recursive|-s|--simple|-l|--load|-g|--visualize)
+        (-h|--help|-V|--version|-r|--recursive|-s|--simple|-L|--load|-g|--visualize)
             args="$args -F $field=select -F ${field}.s=$1"
             leinargs="$leinargs $1"
             ;;
-        (-c|--construct-tpn|-d|--daemonize|-e|--database|-m|--model|-f|--format|-t|--root-task)
+        (-c|--construct-tpn|-d|--daemonize|-e|--database|-m|--model|-f|--format|-t|--root-task|-l|--log-level)
             sw="$1"
             if [ $# -gt 1 ]; then
                 args="$args -F $field=select -F ${field}.s=$1"
@@ -227,20 +228,6 @@ done
 if [ -z "$PAMELAD" ]; then
     vvlog lein $leinargs
     lein $leinargs  | grep -v -E '(^[0-9][0-9]-[0-9][0-9]-[0-9][0-9] |^Successfully compiled)' 2> $errfile
-    # lein sometimes returns non-zero when things are fine
-    rc=0
-    if [ -s "$errfile" ]; then
-        # err "errors were found, please see $errfile"
-        cat "$errfile" 1>&2
-        # no longer required as logging has been all captured with slf4j
-        # egrep -v '(^INFO|org.elasticsearch)' "$errfile" > "$errfile.summary"
-        # if [ -s "$errfile.summary" ]; then
-        #     rc=1
-        # fi
-        rc=1
-    else
-        rm -f "$errfile" "$errfile.summary"
-    fi
 else
     vvlog curl $args
     curl $args
@@ -255,5 +242,13 @@ fi
 if [ -n "$inputtemp" ]; then
     rm "$inputtemp"
 fi
+
+# lein sometimes returns non-zero when things are fine
+if [ -s "$errfile" ]; then
+    # err "errors were found, please see $errfile"
+    cat "$errfile" 1>&2
+    rc=1
+fi
+rm -f "$errfile"
 
 exit $rc

--- a/src/main/clj/pamela/daemon.clj
+++ b/src/main/clj/pamela/daemon.clj
@@ -201,7 +201,7 @@
   [options]
   (let [{:keys [daemonize verbose]} options
         verbose? (pos? (or verbose 0))]
-    (plog/initialize)
+    (plog/initialize (:log-level options))
     (if (= daemonize 65535) ;; graceful shutdown
       ;; NOTE allow the remote request to complete first
       (future

--- a/src/main/clj/pamela/htn.clj
+++ b/src/main/clj/pamela/htn.clj
@@ -1236,7 +1236,7 @@
                                     cname (symbol (str mname "-choice-" j))
                                     subtasks (make-htn-methods pclass :choice nil body irks-j)]
                                 (if (not= type :choice)
-                                  (println "HEY, I EXPECTED a :choice")) ;; FIXME
+                                  (log/error "HEY, I EXPECTED a :choice")) ;; FIXME
                                 (htn-method {:pclass pclass :name cname
                                              :nonprimitive-task nonprimitive-task
                                              :subtasks subtasks
@@ -1279,6 +1279,6 @@
         _ (plan-htn-task expanded-root-task)
         htn (construct-htn-plan-map ir (get-htn-object expanded-root-task))
         tpn @tpn/*tpn-plan-map*]
-    (println "Saving HTN to" htn-filename "and TPN to" tpn-filename)
+    (log/info "Saving HTN to" htn-filename "and TPN to" tpn-filename)
     (output-file stdout? cwd htn-filename file-format htn)
     (output-file stdout? cwd tpn-filename file-format tpn)))

--- a/src/test/cli/01_usage.out
+++ b/src/test/cli/01_usage.out
@@ -12,7 +12,8 @@ Options:
   -e, --database DATABASE          Remote database server name (ES_SERVER)
   -f, --file-format FORMAT  edn    Output file format [edn]
   -i, --input INPUT         ["-"]  Input file (or - for STDIN)
-  -l, --load                       List models in memory only
+  -l, --log-level LEVEL     warn   Logging level
+  -L, --load                       List models in memory only
   -o, --output OUTPUT       -      Output file (or - for STDOUT)
   -a, --magic MAGIC                Magic lvar initializtions
   -m, --model MODEL                Model name

--- a/src/test/clj/testing/pamela/db.clj
+++ b/src/test/clj/testing/pamela/db.clj
@@ -55,7 +55,7 @@
 
 (deftest testing-pamela-db
   (testing "testing-pamela-db"
-    (plog/initialize)
+    (plog/initialize :trace)
     ;; start the database (local iff ES_SERVER not set to a remote DB)
     (is (start-db-pamela (assoc-if {:verbose 0} :server (:es-server env))))
     (when-not (:es-server env)


### PR DESCRIPTION
Closes #17

Nearly all println's are replaced with logging calls.
The logging has been setup with two "appenders"
  1. STDERR
  2. logs/pamela.log
The CLI now accepts --log-level (by default, warn)

A buglet was fixed in cli-test whereby a non-local pamela
script might be executed when running tests.

Signed-off-by: Tom Marble <tmarble@info9.net>