### PR TITLE
Changes to support plan flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file. This change
 Added
 - _TBD_
 
+### [0.4.1] - 2016-10-17
+
+Changes
+- Allow plan-schema to be more flexible
+  https://github.com/dollabs/planviz/issues/24
+- Fixed: Planviz disagrees with Pamela (plan-schema) #18
+- Added the ability to set logging hooks (set-logger!)
+- Added command line switch --strict to enforce schema checking
+- Expand home in pathnames properly
+- Updated dependencies
+
 ### [0.4.0] - 2016-09-29
 
 Changes

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
 ;; in this material are those of the author(s) and do necessarily reflect the
 ;; views of the Army Contracting Command and DARPA.
 
-(defproject pamela "0.4.0"
+(defproject pamela "0.4.1"
   :description "Probabalistic Advanced Modeling and Execution Learning Architecture (PAMELA)"
   :url "https://github.com/dollabs/pamela"
   :scm {:url "https://github.com/dollabs/pamela.git"}
@@ -28,7 +28,7 @@
                  [instaparse "1.4.3"]
                  ;; -------
                  [org.clojure/clojurescript "1.9.229" :scope "provided"]
-                 [org.clojure/core.async "0.2.391"]
+                 [org.clojure/core.async "0.2.395"]
                  [org.clojure/tools.cli "0.3.5"]
                  [riddley "0.1.12"]
                  [environ "1.1.0"]
@@ -46,8 +46,8 @@
                  [cljsjs/react-dom-server "15.3.1-0"]  ;; for sablono
                  [cljsjs/react-dom "15.3.1-0"] ;; for sablono
                  [org.omcljs/om "1.0.0-alpha46"]
-                 [sablono "0.7.4"]
-                 [cljs-http "0.1.41"]]
+                 [sablono "0.7.5"]
+                 [cljs-http "0.1.42"]]
 
   :plugins [[lein-environ "1.1.0"]
             [lein-codox "0.9.5" :exclusions

--- a/src/main/clj/pamela/cli.clj
+++ b/src/main/clj/pamela/cli.clj
@@ -201,7 +201,7 @@
                  (vec output-formats))]]
    ["-i" "--input INPUT" "Input file (or - for STDIN)"
     :default ["-"]
-    :parse-fn #(fs/expand-home %)
+    :parse-fn #(-> % fs/expand-home str)
     :validate [#(or (daemon/running?) (= "-" %) (fs/exists? %))
                "INPUT file does not exist"]
     :assoc-fn (fn [m k v]
@@ -217,7 +217,8 @@
                                        log-levels)))))]
    ["-L" "--load" "List models in memory only"]
    ["-o" "--output OUTPUT" "Output file (or - for STDOUT)"
-    :default "-"]
+    :default "-"
+    :parse-fn #(-> % fs/expand-home str)]
    ["-a" "--magic MAGIC" "Magic lvar initializtions"
     :default nil
     :parse-fn #(fs/expand-home %)
@@ -225,7 +226,8 @@
                "MAGIC file does not exist"]]
    ["-m" "--model MODEL" "Model name"]
    ["-r" "--recursive" "Recursively process model"]
-   ["-s" "--simple" "Simple operation"]
+   ["-s" "--strict" "Enforce strict plan schema checking"]
+   ["-S" "--simple" "Simple operation"]
    ["-t" "--root-task ROOTTASK" "Label for HTN root-task [main]"]
    ["-g" "--visualize" "Render TPN as SVG (set -f dot)"]
    ["-w" "--web WEB" "Web request hints (internal use only)"]
@@ -254,7 +256,7 @@
   - -o, --output *OUTPUT*   **Output file (or - for STDOUT)**
   - -m, --model *MODEL*     **Model name**
   - -r, --recursive         **Recursively process model**
-  - -s, --simple            **Simple operation**
+  - -S, --simple            **Simple operation**
   - -g, --visualize         **Render TPN as SVG (set -f dot)**
   - -w, --web *WEB*         **Web request hints (_internal use only_)**
 
@@ -308,7 +310,7 @@
 (defn pamela
   "PAMELA command line processor. (see usage for help)."
   {:added "0.2.0"
-   :version "0.4.0"}
+   :version "0.4.1"}
   [& args]
   (when (and (:pamela-version env)
           (not= (:pamela-version env) (:version (meta #'pamela))))
@@ -318,7 +320,7 @@
         (parse-opts args cli-options)
         {:keys [help version verbose construct-tpn daemonize database
                 file-format input log-level load output model recursive root-task
-                simple visualize web]} options
+                simple strict visualize web]} options
         log-level (keyword (or log-level "warn"))
         _ (plog/initialize log-level (apply pr-str args))
         cmd (first arguments)
@@ -372,6 +374,7 @@
       (println "recursive:" recursive)
       (println "root-task:" root-task)
       (println "simple:" simple)
+      (println "strict:" strict)
       (println "visualize:" visualize)
       (println "cmd:" cmd (if action "(valid)" "(invalid)")))
     (if-not action

--- a/src/test/cli/01_usage.out
+++ b/src/test/cli/01_usage.out
@@ -18,7 +18,8 @@ Options:
   -a, --magic MAGIC                Magic lvar initializtions
   -m, --model MODEL                Model name
   -r, --recursive                  Recursively process model
-  -s, --simple                     Simple operation
+  -s, --strict                     Enforce strict plan schema checking
+  -S, --simple                     Simple operation
   -t, --root-task ROOTTASK         Label for HTN root-task [main]
   -g, --visualize                  Render TPN as SVG (set -f dot)
   -w, --web WEB                    Web request hints (internal use only)


### PR DESCRIPTION
Allow plan-schema to be more flexible
  https://github.com/dollabs/planviz/issues/24
Fixed: Planviz disagrees with Pamela (plan-schema) (Closes #18)
Added command line switch --strict to enforce schema checking
Expand home in pathnames properly
Updated dependencies

Signed-off-by: Tom Marble <tmarble@info9.net>