### PR TITLE
Minor TPN improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ All notable changes to this project will be documented in this file. This change
 
 Added
 - Better support for magic files (including --output-magic)
-- _TBD_
+- Fixed minor bugs with the pamela launcher
+- Ensured top level actions properly return an exit code
+- Quieted the intial logging by the netty (dependency of aleph)
+- Properly handle default plant bounds as lvars
 
 ### [0.4.2] - 2016-10-18
 

--- a/bin/pamela
+++ b/bin/pamela
@@ -24,8 +24,7 @@ cd "$dir"
 # dir="$(pwd -P)"
 # run from the top directory
 cd ..
-# top="$(pwd -P)"
-top="."
+top="$(pwd -P)"
 logs="$top/logs"
 rc=0
 
@@ -85,7 +84,8 @@ if [ -z "$PAMELAD" ]; then
     if [ -e "$jar" ]; then
         if [ "$PAMELA_MODE" != "dev" ]; then
             vvlog java $PAMELA_OPTS -jar $jar $*
-            exec java $PAMELA_OPTS -jar $jar $* | grep -v -E '(^[0-9][0-9]-[0-9][0-9]-[0-9][0-9] |^Successfully compiled)' 2> $errfile
+            ## exec java $PAMELA_OPTS -jar $jar $* | grep -v -E '(^[0-9][0-9]-[0-9][0-9]-[0-9][0-9] |^Successfully compiled)' 2> $errfile
+            exec java $PAMELA_OPTS -jar $jar $*
         fi
     else
         if [ "$PAMELA_MODE" = "prod" ]; then

--- a/src/main/clj/pamela/daemon.clj
+++ b/src/main/clj/pamela/daemon.clj
@@ -11,6 +11,11 @@
 ;;; in this material are those of the author(s) and do necessarily reflect the
 ;;; views of the Army Contracting Command and DARPA.
 
+;; Prevent aleph from pulling in netty's logging at :debug level
+;; before we properly initialize logging
+(require '(taoensso timbre))
+(taoensso.timbre/set-level! :warn)
+
 (ns pamela.daemon
   "PAMELA daemon support."
   (:require [clojure.java.io :refer :all] ;; for as-file

--- a/src/main/clj/pamela/htn.clj
+++ b/src/main/clj/pamela/htn.clj
@@ -1281,4 +1281,5 @@
         tpn @tpn/*tpn-plan-map*]
     (log/info "Saving HTN to" htn-filename "and TPN to" tpn-filename)
     (output-file stdout? cwd htn-filename file-format htn)
-    (output-file stdout? cwd tpn-filename file-format tpn)))
+    (output-file stdout? cwd tpn-filename file-format tpn)
+    0)) ;; exit code

--- a/src/test/pamela/lvar-examples.pamela
+++ b/src/test/pamela/lvar-examples.pamela
@@ -11,7 +11,7 @@
 ;; in this material are those of the author(s) and do necessarily reflect the
 ;; views of the Army Contracting Command and DARPA.
 
-(defpclass plant []
+(defpclass camera []
   :methods [(defpmethod take-high-res-images
               {:doc "Take High Res Image"
                :bounds (lvar "high-res-bounds" [5 10])}
@@ -19,15 +19,14 @@
             (defpmethod take-medium-res-images
               {:doc "Take Medium Res Image"}
               [])
-            ])
-
-(defpclass example [plant]
-  :methods [(defpmethod main
+            (defpmethod main
               {:doc "the tpn"}
               []
               (choose
                 (choice
-                  (plant.take-high-res-images))
+                  (take-high-res-images))
                 (choice :bounds (lvar "med-res-bounds" [3 6])
-                  (plant.take-medium-res-images)))
-              )])
+                  (take-medium-res-images))))])
+
+(defpclass example [camera]
+  :fields {:imager (camera)})


### PR DESCRIPTION
- Fixed minor bugs with the pamela launcher
- Ensured top level actions properly return an exit code
- Quieted the initial logging by the netty (dependency of aleph)
- Properly handle default plant bounds as lvars

Signed-off-by: Tom Marble <tmarble@info9.net>