### PR TITLE
Improved syntatic and semantic checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Added
 - Quieted the intial logging by the netty (dependency of aleph)
 - Properly handle default plant bounds as lvars
 - Changed default PAMELA_MODE=prod in ./bin/pamela (requires uberjar)
+- Updated grammar to ensure reserved words are not interpreted
+  as plant functions
+- Added semantic check to validate the unqualifed plant functions
+  are defined elsewhere in the PAMELA class
+- Changed dependencies
+  * Upgraded clojurescript, clj-time
+  * Downgraded lein-cljsbuild to avoid migration to the new format
+  * Downgraded org.omcljs/om to 1.0.0-alpha40 to avoid breakage
 
 ### [0.4.2] - 2016-10-18
 

--- a/grammar/resources/data/pamela.ebnf
+++ b/grammar/resources/data/pamela.ebnf
@@ -52,7 +52,7 @@ trans = ( doc | pre | post | opt-bounds | cost | reward | probability )
 pre = <PRE> ( keyword | cond-expr )
 post = <POST> ( keyword | cond-expr )
 
-fn = ( ask | assert | choose | choose-whenever | optional | maintain | delay | parallel | slack-parallel | soft-parallel | plant-fn | sequence | slack-sequence | soft-sequence | tell | try | unless | when | whenever | dotimes )
+fn = ( ask | assert | choose | choose-whenever | optional | maintain | delay | parallel | slack-parallel | soft-parallel | sequence | slack-sequence | soft-sequence | tell | try | unless | when | whenever | dotimes | plant-fn )
 
 ask = <LP> <ASK> cond-expr opt-bounds? <RP>
 assert = <LP> <ASSERT> cond-expr opt-bounds? <RP>
@@ -67,7 +67,8 @@ parallel = <LP> <PARALLEL> fn-opt* fn+ <RP>
 slack-parallel = <LP> <SLACK_PARALLEL> fn-opt* fn+ <RP>
 soft-parallel = <LP> <SOFT_PARALLEL> fn-opt* fn+ <RP>
 plant-fn = <LP> ( symbol <'.'> symbol | plant-fn-symbol | keyword ) plant-opt* argval* <RP>
-plant-fn-symbol = !DELAY symbol
+plant-fn-symbol = !reserved-fn-symbol symbol
+reserved-fn-symbol = ( <ASK> | <ASSERT> | <CHOOSE> | <CHOOSE_WHENEVER> | <OPTIONAL> | <MAINTAIN> | <DELAY> | <PARALLEL> | <SLACK_PARALLEL> | <SOFT_PARALLEL> | <SEQUENCE> | <SLACK_SEQUENCE> | <SOFT_SEQUENCE> | <TELL> | <TRY> | <UNLESS> | <WHEN> | <WHENEVER> | <DOTIMES> )
 sequence = <LP> <SEQUENCE> fn-opt* fn+ <RP>
 slack-sequence = <LP> <SLACK_SEQUENCE> fn-opt* fn+ <RP>
 soft-sequence = <LP> <SOFT_SEQUENCE> fn-opt* fn+ <RP>

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [instaparse "1.4.3"]
                  ;; -------
-                 [org.clojure/clojurescript "1.9.229" :scope "provided"]
+                 [org.clojure/clojurescript "1.9.293" :scope "provided"]
                  [org.clojure/core.async "0.2.395"]
                  [org.clojure/tools.cli "0.3.5"]
                  [riddley "0.1.12"]
@@ -37,7 +37,7 @@
                  [clj-http "3.3.0"]
                  [clojurewerkz/elastisch "2.2.2"]
                  [aleph "0.4.2-alpha8"]
-                 [clj-time "0.12.0"]
+                 [clj-time "0.12.2"]
                  [ring "1.5.0"]
                  [ring/ring-defaults "0.2.1"]
                  [compojure "1.5.1"]
@@ -45,14 +45,14 @@
                  [org.clojure/data.json "0.2.6"]
                  [cljsjs/react-dom-server "15.3.1-0"]  ;; for sablono
                  [cljsjs/react-dom "15.3.1-0"] ;; for sablono
-                 [org.omcljs/om "1.0.0-alpha46"]
+                 [org.omcljs/om "1.0.0-alpha40"]
                  [sablono "0.7.5"]
                  [cljs-http "0.1.42"]]
 
   :plugins [[lein-environ "1.1.0"]
             [lein-codox "0.9.5" :exclusions
              [org.clojure/clojure org.clojure/clojurescript]]
-            [lein-cljsbuild "1.1.3" :exclusions [org.clojure/clojure]]
+            [lein-cljsbuild "1.1.2" :exclusions [org.clojure/clojure]]
             [lein-figwheel "0.5.3-1"
              :exclusions [org.clojure/clojure org.clojure/clojurescript]]]
 

--- a/src/main/clj/pamela/tpn.clj
+++ b/src/main/clj/pamela/tpn.clj
@@ -890,6 +890,7 @@
 ;; else
 ;;   ONE of the pclasses must be the plant (zero args)
 ;;   and the OTHER pclass must be the TPN and have exactly one zero arg pmethod
+;; NOTE: return {:error "message"} on failure
 (defn load-tpn [ir options]
   (let [{:keys [construct-tpn file-format cwd output]} options
         [tpn-ks args] (if construct-tpn
@@ -897,14 +898,14 @@
                         (find-tpn-method-default ir))
         tpn (if tpn-ks
               (create-tpn ir tpn-ks args)
-              false)
+              {:error "unable to find TPN method based on --construct argument"})
         stdout? (daemon/stdout? output)
         output-filename (if (not stdout?)
                           (if (fs/absolute? output)
                             output
                             (str cwd "/" output)))]
-    (if tpn
+    (if (:error tpn)
+      tpn
       (do
         (output-file stdout? cwd output-filename file-format tpn)
-        true)
-      false))) ;; return success
+        tpn))))

--- a/src/test/pamela/biased-coin.pamela
+++ b/src/test/pamela/biased-coin.pamela
@@ -57,10 +57,15 @@
                       (emit-head))
                     (choice :probability (lvar "eUT" 0.49)
                       (emit-tail))))))
-            (defpmethod flip-sequence
-              {:doc "Series of coin flips"}
+            (defpmethod flip-3
+              {:doc "Series of 3 coin flips"}
               []
-              (dotimes 10 (flip)))])
+              (dotimes 3 (flip)))
+            (defpmethod flip-1000
+              {:doc "Series of 1000 coin flips"}
+              []
+              (dotimes 1000 (flip)))
+            ])
 
 (defpclass main []
   :fields {:coin (coin)})


### PR DESCRIPTION
Updated grammar to ensure reserved words are not interpreted
  as plant functions
Added semantic check to validate the unqualifed plant functions
  are defined elsewhere in the PAMELA class
Changed dependencies
 * Upgraded clojurescript, clj-time
 * Downgraded lein-cljsbuild to avoid migration to the new format
 * Downgraded org.omcljs/om to 1.0.0-alpha40 to avoid breakage
Fixes BB 98: TPN for dotimes is unexpected

Signed-off-by: Tom Marble <tmarble@info9.net>