### PR TITLE
Redesigned input-file and output-file processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Added
   * Upgraded clojurescript, clj-time
   * Downgraded lein-cljsbuild to avoid migration to the new format
   * Downgraded org.omcljs/om to 1.0.0-alpha40 to avoid breakage
+- Redesigned input-file and output-file processing (to expand-home
+  and prepend the current working directory as needed)
 
 ### [0.4.2] - 2016-10-18
 

--- a/src/main/clj/pamela/parser.clj
+++ b/src/main/clj/pamela/parser.clj
@@ -869,7 +869,7 @@
 
 ;; return PAMELA IR or {:error "message"}
 (defn parse [options]
-  (let [{:keys [cwd input magic output-magic]} options
+  (let [{:keys [input magic output-magic]} options
         parser (build-parser)
         mir (if magic (parse-magic magic) {})]
     (when magic
@@ -889,19 +889,16 @@
           (if out-magic
             (do
               (if output-magic
-                (spit output-magic out-magic))
+                (output-file output-magic "edn" out-magic))
               (assoc ir
                 'pamela/lvars
                 {:type :lvars
                  :lvars lvars}))
             ir))
-        (let [input-file (fs/file (if (fs/exists? input-filename)
-                                    input-filename
-                                    (str cwd "/" input-filename)))
-              tree (if (fs/exists? input-file)
-                     (insta/parses parser (slurp input-file)))
+        (let [tree (if (fs/exists? input-filename)
+                     (insta/parses parser (slurp input-filename)))
               ir (cond
-                   (not (fs/exists? input-file))
+                   (not (fs/exists? input-filename))
                    (let [msg (str "parse: input file not found: "
                                input-filename)]
                      (log/error msg)

--- a/src/main/clj/pamela/tpn.clj
+++ b/src/main/clj/pamela/tpn.clj
@@ -892,20 +892,16 @@
 ;;   and the OTHER pclass must be the TPN and have exactly one zero arg pmethod
 ;; NOTE: return {:error "message"} on failure
 (defn load-tpn [ir options]
-  (let [{:keys [construct-tpn file-format cwd output]} options
+  (let [{:keys [construct-tpn file-format output]} options
         [tpn-ks args] (if construct-tpn
                         (find-tpn-method-construct ir construct-tpn)
                         (find-tpn-method-default ir))
         tpn (if tpn-ks
               (create-tpn ir tpn-ks args)
-              {:error "unable to find TPN method based on --construct argument"})
-        stdout? (daemon/stdout? output)
-        output-filename (if (not stdout?)
-                          (if (fs/absolute? output)
-                            output
-                            (str cwd "/" output)))]
+              {:error
+               "unable to find TPN method based on --construct argument"})]
     (if (:error tpn)
       tpn
       (do
-        (output-file stdout? cwd output-filename file-format tpn)
+        (output-file output file-format tpn)
         tpn))))


### PR DESCRIPTION
Now filenames are run through expand-home and prepend the
current working directory as needed.

Closes #33

Signed-off-by: Tom Marble <tmarble@info9.net>