### PR TITLE
Updated PAMELA grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file. This change
 ### [Unreleased]
 
 Changes
-* _TBD_
+* Grammar changes: allow underscores in symbols
+* Parsing changes: allow plant-function symbols to refer to fields
+  (if not present in method or pclass args)
 
 ### [0.5.0] - 2016-12-08
 

--- a/build.boot
+++ b/build.boot
@@ -34,6 +34,7 @@
                     [instaparse                "1.4.3"]
                     [avenir                    "0.2.1"]
                     [me.raynes/fs              "1.4.6"]
+                    [camel-snake-kebab         "0.4.0"]
                     ;; testing
                     [adzerk/boot-test          "1.1.2" :scope "test"]])
 

--- a/resources/public/pamela.ebnf
+++ b/resources/public/pamela.ebnf
@@ -125,12 +125,12 @@ interface = <INTERFACE> string
 bounds = bounds-literal | lvar-ctor
 bounds-literal = <LB> number ( number | INFINITY ) <RB>
 
-symbol = !boolean #'[A-Za-z][A-Za-z0-9-]*'
+symbol = !boolean #'[A-Za-z][A-Za-z0-9-_]*'
 literal = ( boolean | string | keyword | number )
 argval = ( symbol | boolean | string | number | safe-keyword )
 safe-keyword = !reserved-keyword keyword
 reserved-keyword = ( <LABEL> | <BOUNDS> | <COST> | <REWARD> | <CONTROLLABLE> )
-keyword = <':'> #'[A-Za-z0-9:*-.]+'
+keyword = <':'> #'[A-Za-z0-9:*-_.]+'
 boolean = ( TRUE | FALSE )
 string = <'"'>  #'[^"]*' <'"'>
 number = ( float | integer )

--- a/src/pamela/utils.clj
+++ b/src/pamela/utils.clj
@@ -108,3 +108,13 @@
   {:pamela :utils :added "0.2.0"}
   [s]
   (Thread/sleep (* 1000 s)))
+
+(defn user-tmpdir [program]
+  (let [tmp (:java-io-tmpdir env)
+        user (:user env)
+        tmpdir (str tmp "/" user "/" program)]
+    (if (fs/exists? tmpdir)
+      tmpdir
+      (do
+        (fs/mkdirs tmpdir)
+        tmpdir))))

--- a/test/clj/testing/pamela/parser.clj
+++ b/test/clj/testing/pamela/parser.clj
@@ -13,7 +13,12 @@
 
 (ns testing.pamela.parser
   (:require [clojure.test :refer :all]
-            [pamela.parser :refer :all]))
+            [clojure.string :as string]
+            [environ.core :refer [env]]
+            [me.raynes.fs :as fs]
+            [avenir.utils :refer [and-fn]]
+            [pamela.parser :refer :all]
+            [pamela.utils :refer [output-file]]))
 
 (deftest testing-pamela-parser
   (testing "testing-pamela-parser"
@@ -83,4 +88,24 @@
                          :doc "Simple Choice TPN"}}}}]
       (is (= choice-ir
             (parse {:input [choice-pamela] :output "-"}))))
-    ))
+    (let [top (:user-dir env)
+          regression (fs/file top "test" "pamela" "regression")
+          examples (filter #(string/ends-with? (fs-file-name %) ".pamela")
+                     (fs/list-dir regression))
+          tmpdir (fs/file top "target" "regression")]
+      (if-not (fs/exists? tmpdir)
+        (fs/mkdirs tmpdir))
+      (doseq [example examples]
+        (let [example-name (fs-file-name example)
+              output (str tmpdir "/"
+                       (string/replace example-name
+                         #"\.pamela$" ".ir.edn"))
+              options {:input [example]}
+              ir (parse options)
+              success? (nil? (:error ir))]
+          (output-file output
+            (if success? "edn" "string")
+            (if success? ir (:error ir)))
+          (if-not success?
+            (println "ERROR in" output))
+          (is success?))))))

--- a/test/pamela/regression/switch-bulb.pamela
+++ b/test/pamela/regression/switch-bulb.pamela
@@ -1,0 +1,39 @@
+;; Copyright © 2016 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+;; Acknowledgement and Disclaimer:
+;; This material is based upon work supported by the Army Contracting
+;; and DARPA under contract No. W911NF-15-C-0005.
+;; Any opinions, findings and conclusions or recommendations expressed
+;; in this material are those of the author(s) and do necessarily reflect the
+;; views of the Army Contracting Command and DARPA.
+
+;; Switch and Bulb Example
+
+(defpclass psw []
+  :meta { :doc "A power switch" }
+  :methods [(defpmethod turn_on
+              [])
+            (defpmethod turn_off
+              [])])
+
+(defpclass main []
+  :meta { :doc "An example circuit: power switch and light bulb" }
+  :fields {:switchedpower (psw :id "switchedcircuit" :plant-part "psw1")}
+  :methods [(defpmethod turn-on-switch []
+              (:switchedpower.turn_on)) ;; field reference plant-fn
+            (defpmethod turn-off-switch []
+              (switchedpower.turn_off)) ;; implied field reference plant-fn
+            (defpmethod toggle-switch []
+              (sequence
+                (turn-on-switch)
+                (delay :bounds [10 10])
+                (turn-off-switch)
+                (delay :bounds [10 10])))
+            (defpmethod demo []
+              (dotimes 3
+                (toggle-switch)))
+            ])


### PR DESCRIPTION
* Grammar changes: allow underscores in symbols
* Parsing changes: allow plant-function symbols to refer to fields
  (if not present in method or pclass args)

Signed-off-by: Tom Marble <tmarble@info9.net>