### PR TITLE
Add arity checks in IR generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changes
 * Make it explicit that there can't be multiple levels of ( parallel | sequence | choose ) in a
   defpmethod used for HTN generation (Closes #57)
 * HTN and TPN schema updates (one of many steps on Issue #43)
+* Avoid recursive resolve-plant-class call at the end of the ancestry-path (Closes #82)
+* Check method call arity in IR generation (if possible) (Closes #83)
 
 ### [0.6.0] - 2017-03-08
 


### PR DESCRIPTION
Avoid recursive resolve-plant-class call at the end of the ancestry-path (Closes #82)
Check method call arity in IR generation (if possible) (Closes #83)

Signed-off-by: Tom Marble <tmarble@info9.net>