### PR TITLE
Relax build verification indirect method arity

### DIFF
--- a/src/pamela/parser.clj
+++ b/src/pamela/parser.clj
@@ -803,7 +803,16 @@
                                 (validate-arity in-pclass in-method in-mi
                                   pclass (get-in ir [pclass :methods])
                                   method args)
-                                {:error "non :pclass-ctor check unsupported"})]
+                                ;; NOTE: in the past we just gave up on
+                                ;; checking arity here for fields that
+                                ;; are initialized from pclass args.
+                                ;; Now we will *assume* the arity is fine
+                                ;; and will catch it once we evaluate
+                                ;; an actual root-task
+                                ;; {:error "non :pclass-ctor check unsupported"}
+                                ;; NOTE below is simply an arbitrary value
+                                ;; to set mdef instead of error
+                                {:mdef "arity not checked at build time"})]
                           (if error
                             [nil error]
                             [(assoc (dissoc b :name)

--- a/test/pamela/pending/IR/issue-81-nocolons2.ir.edn
+++ b/test/pamela/pending/IR/issue-81-nocolons2.ir.edn
@@ -2,7 +2,7 @@
  {:type :pclass,
   :args [],
   :fields
-  {sp1
+  {:sp1
    {:access :private,
     :observable false,
     :initial
@@ -12,7 +12,7 @@
      :id "sp1",
      :plant-part "mypart",
      :interface "RMQ"}},
-   sp2
+   :sp2
    {:access :private,
     :observable false,
     :initial
@@ -22,7 +22,7 @@
      :id "sp2",
      :plant-part "mypart2",
      :interface "RMQ"}},
-   run
+   :run
    {:access :private,
     :observable false,
     :initial
@@ -32,11 +32,11 @@
   :args [plant1 plant2],
   :meta {:doc "Coverage Test"},
   :fields
-  {p1
+  {:p1
    {:access :private,
     :observable false,
     :initial {:type :arg-reference, :name plant1}},
-   p2
+   :p2
    {:access :private,
     :observable false,
     :initial {:type :arg-reference, :name plant2}}},
@@ -57,23 +57,18 @@
        :body
        [{:type :plant-fn-field,
          :method scp,
-         :args [{:type :field-deref,
-                 :field p2,
-                 :deref data1}
-                {:type :field-deref,
-                 :field p2,
-                 :deref data2}],
-         :field p2}]}],
+         :args [:p2_data1 :p2_data2],
+         :field :p2}]}],
      :doc "The HTN"}]}},
  simpleplant
  {:type :pclass,
   :args [],
   :fields
-  {data1
+  {:data1
    {:access :private,
     :observable false,
     :initial {:type :literal, :value 123}},
-   data2
+   :data2
    {:access :private,
     :observable false,
     :initial {:type :literal, :value "fred"}}},
@@ -81,12 +76,12 @@
   {:bykw
    {:type :equal,
     :args
-    [{:type :field-reference, :pclass this, :field data1}
+    [{:type :field-reference, :pclass this, :field :data1}
      {:type :literal, :value 123}]},
    :bysym
    {:type :equal,
     :args
-    [{:type :field-reference, :pclass this, :field data2}
+    [{:type :field-reference, :pclass this, :field :data2}
      {:type :literal, :value "fred"}]}},
   :methods
   {hardwork

--- a/test/pamela/pending/issue-81-nocolons2.pamela
+++ b/test/pamela/pending/issue-81-nocolons2.pamela
@@ -1,0 +1,65 @@
+;; Copyright © 2016 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+;; Acknowledgement and Disclaimer:
+;; This material is based upon work supported by the Army Contracting
+;; and DARPA under contract No. W911NF-15-C-0005.
+;; Any opinions, findings and conclusions or recommendations expressed
+;; in this material are those of the author(s) and do necessarily reflect the
+;; views of the Army Contracting Command and DARPA.
+
+;; Test for #81
+
+(defpclass simpleplant []
+  :fields {:data1 123
+           :data2 "fred"}
+  :modes {:bykw (= :data1 123)
+          :bysym (= :data2 "fred")}
+  :methods [(defpmethod hardwork
+              {:doc "Simulated work with a simulated failure"
+               :bounds [1 20]}
+              [time])
+            (defpmethod scp
+              {:doc "Secure network file copy"
+               :bounds [10 20]}
+              [fromfile tofile])
+            (defpmethod cp
+              {:doc "local file copy"
+               :display-name "Copy"}
+              [fromfile tofile])
+            (defpmethod shell
+              {:doc "Runs a command-line program"
+               :bounds [0 3]}
+              [cmd arg1 arg2 arg3])
+            (defpmethod python
+              {:doc "Runs a python script"}
+              [script options arg1 arg2 arg3])
+            (defpmethod stop
+              {:doc    "Stops the plant"
+               :bounds [0 1]
+               :controllable true}
+              [area])
+            ])
+
+(defpclass coverage-test [plant1 plant2]
+  :meta {:doc "Coverage Test"}
+
+  :fields {:p1 plant1
+           :p2 plant2}
+
+  :methods [(defpmethod main
+              {:doc "The HTN"}
+              []
+              (sequence
+                (p2.scp :p2_data1 :p2_data2) ;; we NOW want to deref plant fields
+                ))
+            ])
+
+;; root-task: "(coverage-demo.run.main)"
+(defpclass coverage-demo []
+  :fields {:sp1 (simpleplant :id "sp1" :plant-part "mypart" :interface "RMQ")
+           :sp2 (simpleplant :id "sp2" :plant-part "mypart2" :interface "RMQ")
+           :run (coverage-test sp1 sp2)})


### PR DESCRIPTION
In order to complete the proposed IR change for #81
the motivating example
  test/pamela/pending/issue-81-nocolons.pamela
was copied to "current legal" PAMELA syntax in
  test/pamela/pending/issue-81-nocolons2.pamela
in order to create
  test/pamela/pending/IR/issue-81-nocolons2.ir.edn
as the basis for
  test/pamela/pending/IR/issue-81-nocolons.ir.edn

The impact of the change is that arity (signature) match
verification when an indirect method is called will be
deferred to when the root-task is available (i.e. the
entire call graph).

Signed-off-by: Tom Marble <tmarble@info9.net>