### PR TITLE
Added pseudo fixture for handing stdout/stderr for tests

### DIFF
--- a/src/pamela/cli.clj
+++ b/src/pamela/cli.clj
@@ -214,7 +214,7 @@
       (log/error \newline (string/join \newline msgs))))
   (flush) ;; ensure all pending output has been flushed
   (if (or (repl?) test-mode)
-    (log/warn "exit" status "pamela in DEV MODE. Not exiting" "repl?" (repl?) "test-mode" test-mode)
+    (log/info "exit" status "pamela in DEV MODE. Not exiting" "repl?" (repl?) "test-mode" test-mode)
     (do (log/info "exiting with status" status)
       (shutdown-agents)
         (System/exit status)))

--- a/test/clj/testing/pamela/cli.clj
+++ b/test/clj/testing/pamela/cli.clj
@@ -13,9 +13,68 @@
 
 (ns testing.pamela.cli
   (:require [clojure.test :refer :all]
+            [clojure.string :as string]
             [me.raynes.fs :as fs]
             [testing.pamela.parser :refer [fs-get-path]]
             [pamela.cli :refer :all]))
+
+;; out-expect should
+;;   nil if we don't care about matching stdout
+;;   #"regex" -- a string (converted to regex) or regex that stdout should match
+;;     NOTE newlines are stripped from stdout before the match such that
+;;     the expression '.*' will match across lines
+;; err-expect is analogous to out-expect, for stderr
+;; the return value is [rv out-match err-match]
+;; where
+;;    rv is the value of the evaluated body
+;;    out-match is true for a match (or if we don't care),
+;;       else it is an error string explaining the match failed
+;;    err-match is analogous to out-match, but for stderr
+(defmacro match-eval-out-err
+  "Evaluates exprs in a context in which *out* and *err* are bound to a fresh
+  StringWriter.  Prints *out* and *err* after execution."
+  [out-expect err-expect & body]
+  `(let [out# (new java.io.StringWriter)
+         err# (new java.io.StringWriter)
+         [rv# out-str# err-str#]
+         (binding [*out* out#
+                   *err* err#]
+           [~@body (str out#) (str err#)])
+         out-pattern# (cond
+                        (nil? ~out-expect)
+                        nil
+                        (string? ~out-expect)
+                        (re-pattern ~out-expect) ;; promote to pattern
+                        (instance? java.util.regex.Pattern ~out-expect)
+                        ~out-expect
+                        :else
+                        nil)
+         out-rv# (or (not out-pattern#) ;; we don't care about out
+                   (if (re-find out-pattern#
+                         (string/replace out-str# "\n" ""))
+                     true ;; we have a match
+                     (str "stdout did NOT match '" out-pattern# "' ===\n"
+                       out-str# "\n===")))
+         err-pattern# (cond
+                        (nil? ~err-expect)
+                        nil
+                        (string? ~err-expect)
+                        (re-pattern ~err-expect) ;; promote to pattern
+                        (instance? java.util.regex.Pattern ~err-expect)
+                        ~err-expect
+                        :else
+                        nil)
+         err-rv# (or (not err-pattern#) ;; we don't care aberr err
+                   (if (re-find err-pattern#
+                         (string/replace err-str# "\n" ""))
+                     true ;; we have a match
+                     (str "stderr did NOT match '" err-pattern# "' ===\n"
+                       err-str# "\n===")))]
+     ;; DEBUG
+     ;; (println "OUT=>" out-str# "<=OUT")
+     ;; (println "ERR=>" err-str# "<=ERR")
+     ;; (println "MATCH?" err-pattern# "="(re-find err-pattern# err-str#))
+     [rv# out-rv# err-rv#]))
 
 (deftest testing-pamela-cli
   (testing "testing-pamela-cli"
@@ -26,28 +85,52 @@
 
     (set-test-mode! true) ;; no need to set repl-mode
 
-    (binding [*out* (new java.io.StringWriter)] ;; discard *out*
-      ;; check PASS
-      (is (= 0 (pamela "-i" "test/pamela/circuit.pamela" "check" )))
-      ;; check FAIL
-      (is (= 1 (pamela "-i" "bogus.pamela" "check")))
-      ;; build PASS
-      (is (= 0 (pamela "-i" "test/pamela/circuit.pamela" "build" )))
-      ;; build FAIL
-      (is (= 1 (pamela "-i" "test/pamela/errors/IR/issue-86b.pamela" "build")))
-      ;; tpn PASS
-      (is (= 0 (pamela "-i" "test/pamela/plant.pamela"
-                 "-i" "test/pamela/parallel-choice.tpn.pamela"
-                 "tpn" )))
-      ;; tpn FAIL
-      (is (= 1 (pamela "-i" "test/pamela/parallel-choice.tpn.pamela" "tpn")))
-      ;; htn PASS
-      (is (= 0 (pamela "-i" "test/pamela/lvar-examples.pamela"
-                 "-t" "(example.imager.main)"
-                 "htn")))
-      ;; htn FAIL
-      (is (= 1 (pamela "-i" "test/pamela/tpn-demo.pamela"
-                 "-t" "(tpn.elephant)"
-                 "htn")))
-      )
+    ;; check PASS
+    (is (= [0 true true]
+          (match-eval-out-err #":defpclass.*pwrvals" nil
+            (pamela "-i" "test/pamela/circuit.pamela" "check" )
+            )))
+        ;; check FAIL
+    (is (= [1 true true]
+          (match-eval-out-err nil #"bogus.pamela.*INPUT file does not exist"
+            (pamela "-i" "bogus.pamela" "check")
+            )))
+
+    ;; build PASS
+    (is (= [0 true true]
+          (match-eval-out-err "\\{bulb \\{:type :pclass" nil
+            (pamela "-i" "test/pamela/circuit.pamela" "build" )
+            )))
+    ;; build FAIL
+    (is (= [1 true true]
+          (match-eval-out-err nil #"unable to parse:.*issue-86b.pamela"
+            (pamela "-i" "test/pamela/errors/IR/issue-86b.pamela" "build")
+            )))
+
+    ;; tpn PASS
+    (is (= [0 true true]
+          (match-eval-out-err "tpn-type.*activity" nil
+            (pamela "-i" "test/pamela/plant.pamela"
+              "-i" "test/pamela/parallel-choice.tpn.pamela"
+              "tpn" ))))
+    ;; tpn FAIL
+    (is (= [1 true true]
+          (match-eval-out-err nil "unable to find the default TPN method: please specify --construct-tpn"
+            (pamela "-i" "test/pamela/parallel-choice.tpn.pamela" "tpn")
+            )))
+
+    ;; htn PASS
+    (is (= [0 true true]
+          (match-eval-out-err "type.*htn-expanded-method" nil
+          (pamela "-i" "test/pamela/lvar-examples.pamela"
+            "-t" "(example.imager.main)"
+            "htn")
+          )))
+    ;; htn FAIL
+    (is (= [1 true true]
+          (match-eval-out-err nil "Embedding a :parallel is not supported within a defpmethod when used for HTN generation"
+          (pamela "-i" "test/pamela/tpn-demo.pamela"
+            "-t" "(tpn.elephant)"
+            "htn")
+          )))
     ))


### PR DESCRIPTION
A problem with adding "negative" tests is that we expect
errors and, previously, these actions would blurt error
messages (typically on stderr).

This fix introduces the #'match-eval-out-err macro which
can be used it tests to:
1. Verify the expected exit code (or arbitrary return value)
2. (Optionally) ensure stdout contains a regex.
3. (Optionally) ensure stderr contains a regex.

In addition to testing for a failure exit code this macro
helps ensure that for both positive and negative test cases
that the output has (at least) some sanity as represented
by the given regex and neither stream pollutes the test
output (which could lead to confusion about the overall
success of tests).

Signed-off-by: Tom Marble <tmarble@info9.net>