### PR TITLE
More special handling of ‘delay’ statements.  

### DIFF
--- a/src/pamela/htn.clj
+++ b/src/pamela/htn.clj
@@ -1573,7 +1573,9 @@
                                                  (if plant-id (str plant-id "."))
                                                  interface))
                                  :display-name (str (:display-name details_)
-                                                    (seq (to-pamela (:args details_)))))
+                                                    (if (= name 'delay)
+                                                      nil
+                                                      (seq (to-pamela (:args details_))))))
                          :command (:name details_)
                          :display-name (:display-name details_) ;; to be removed
                          :label (:label details_) ;; to be removed


### PR DESCRIPTION
Eliminates a warning that was hidden by all of the previous chatter in the test output.