### PR TITLE
Fixed incorrect IR for conditional Pamela statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Changes
   unnecessarily (Closes #115)
 * Update doc/PAMELA.md to include documentation for all of the Pamela built-in statements
 * Added unparse action (Closes #125)
+* Fixed statements include ask, assert, maintain, unless, when, whenever
+  (Closes #122)
+* Updated plan-schema dependency to 0.3.6
 
 ### [0.6.0] - 2017-03-08
 

--- a/build.boot
+++ b/build.boot
@@ -35,7 +35,7 @@
                     [avenir                    "0.2.2"]
                     [me.raynes/fs              "1.4.6"]
                     [camel-snake-kebab         "0.4.0"]
-                    [dollabs/plan-schema       "0.3.5"]
+                    [dollabs/plan-schema       "0.3.6"]
                     ;; testing
                     [adzerk/boot-test          "1.1.2" :scope "test"]
                     [criterium                 "0.4.4" :scope "test"]

--- a/src/pamela/cli.clj
+++ b/src/pamela/cli.clj
@@ -76,7 +76,7 @@
         (log/errorf "unable to parse: %s\nerror: %s" input (:error ir))
         1)
       (do
-        (output-file output "edn" ir)
+        (output-file output "edn-mixed" ir)
         (when source
           (output-file source "raw" (unparser/unparse ir)))
         0))))

--- a/src/pamela/unparser.clj
+++ b/src/pamela/unparser.clj
@@ -260,9 +260,7 @@
                 catch label enter leave]} fn
         bounds (unparse-temporal-constraints temporal-constraints)]
     (cond
-      (#{:ask :assert :choose :choose-whenever :maintain
-         :delay :parallel :sequence :tell :unless :when :whenever
-         :catch} type)
+      (#{:choose :choose-whenever :delay :parallel :sequence :tell :catch} type)
       (let [body-src (if-not (empty? body) (map unparse-fn body))
             body-src (if (nil? controllable)
                        body-src
@@ -293,6 +291,15 @@
             body-src (if label
                          (cons :label (cons label body-src))
                          body-src)]
+        (cons (symbol (clojure.core/name type)) body-src))
+      (#{:ask :assert :maintain :unless :when :whenever} type)
+      (let [body-src (if-not (empty? body) (map unparse-fn body))
+            body-src (if bounds
+                         (cons :bounds (cons bounds body-src))
+                         body-src)
+            body-src (if condition
+                       (cons (unparse-cond-expr condition) body-src)
+                       body-src)]
         (cons (symbol (clojure.core/name type)) body-src))
       (= type :try)
       (let [catch-src (if-not (empty? catch)

--- a/src/pamela/utils.clj
+++ b/src/pamela/utils.clj
@@ -25,76 +25,7 @@
             [camel-snake-kebab.core :as translate]
             [avenir.utils :refer [str-append]]
             [clojure.tools.logging :as log]
-            [plan-schema.utils :refer [sort-map]])
-  (:import [java.lang ;; required by sort-map2
-            Number]
-           [java.util
-            Comparator]
-           [java.io
-            Serializable]
-           [clojure.lang
-            Numbers]))
-
-;; implementation of sort-map2 -- to move to plan-schema.utils -------------
-
-(defn compare-by-class
-  "Compare two objects. If they are of the same class use the class
-   specific Comparator else compare on the class name"
-  [o1 o2]
-  (if (nil? o1)
-    (if (nil? o2)
-      0   ;; nil == nil
-      -1) ;; nil < non-nil
-    (if (nil? o2)
-      1   ;; non-nil > nil
-      (let [c1 (class o1)
-            c2 (class o2)]
-        (if (= c1 c2) ;; same class?
-          (if (number? o1)
-            (Numbers/compare o1 o2) ;; numeric comparison
-            (.compareTo o1 o2))     ;; non-numeric comparison
-          (.compareTo (.getName c1) (.getName c2))))))) ;; compare on class name
-
-(declare default-comparator-by-class)
-
-;; This is a special "interface' of Serializable
-;; http://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html
-(definterface ReadResolve
-  (readResolve []))
-
-;; implements Comparator, Serializable
-(deftype comparator-by-class []
-  Comparator
-  (compare [_ o1 o2]
-    (compare-by-class o1 o2))
-  ReadResolve ;; Serializable
-  (readResolve [_]
-    default-comparator-by-class))
-
-(def default-comparator-by-class (->comparator-by-class))
-
-(defn sorted-map-by-class
-  "Like sorted-map, but uses compare-by-class such that maps with
-   heterogeneously typed keys will always sort into a consistent, stable order"
-  [& keyvals]
-  (apply sorted-map-by default-comparator-by-class keyvals))
-
-(defn sort-map2
-  "Returns a map (including any nested maps) are in sorted order"
-  {:added "0.3.3"}
-  ([v]
-   (cond
-     (map? v)
-     (reduce-kv sort-map2 (sorted-map-by-class) v)
-     :else v))
-  ([m k v]
-   (assoc m k
-     (cond
-       (map? v)
-       (reduce-kv sort-map2 (sorted-map-by-class) v)
-       :else v))))
-
-;; --------------------------------------------------------------------
+            [plan-schema.sorting :refer [sort-map sort-mixed-map]]))
 
 (defn stdout?
   "Returns true if the output file name is STDOUT (or running as pamelad)"
@@ -112,8 +43,9 @@
 (defn get-cwd []
   @cwd)
 
-;; file-format's supported: edn json string
-;; if input is a map, sort it
+;; file-format's supported: edn edn-mixed json string
+;; if input is a map, sort it as a homogeneous key map
+;;    unless the format is edn-mixed = sort as heterogeneous keymap
 (defn output-file [filename file-format data]
   (binding [*print-length* nil] ;;Just in case someone has this set in their environment
     (let [is-stdout? (stdout? filename)
@@ -125,10 +57,12 @@
                               (fs/file filename)
                               (fs/file (get-cwd) filename)))
           data (if (map? data)
-                 (sort-map2 data)
+                 (if (= file-format "edn-mixed")
+                   (sort-mixed-map data)
+                   (sort-map data))
                  data)
           out (cond
-                (= file-format "edn")
+                (#{"edn" "edn-mixed"} file-format)
                 (with-out-str (pprint data))
                 (= file-format "json")
                 (with-out-str (json/pprint data))

--- a/test/pamela/HTN/statements.main.tpn.edn
+++ b/test/pamela/HTN/statements.main.tpn.edn
@@ -1,4 +1,4 @@
-{:act-13
+{:act-14
  {:args
   [{:type :equal,
     :args
@@ -11,16 +11,16 @@
      {:type :literal, :value :illuminated}],
     :type :equal}},
   :command "assert",
-  :constraints #{},
+  :constraints #{:tc-13},
   :controllable false,
   :display-name "Assert",
-  :end-node :node-18,
+  :end-node :node-20,
   :htn-node :hem-23,
   :name "Assert((= foo :illuminated))",
   :plantid "bsm1",
   :tpn-type :activity,
-  :uid :act-13},
- :act-17
+  :uid :act-14},
+ :act-19
  {:args
   [{:type :equal,
     :args
@@ -33,16 +33,16 @@
      {:type :literal, :value :dead}],
     :type :equal}},
   :command "ask",
-  :constraints #{},
+  :constraints #{:tc-18},
   :controllable false,
   :display-name "Ask",
-  :end-node :node-22,
+  :end-node :node-25,
   :htn-node :hem-23,
   :name "Ask((= bar :dead))",
   :plantid "bsm1",
   :tpn-type :activity,
-  :uid :act-17},
- :act-21
+  :uid :act-19},
+ :act-24
  {:args
   [{:type :equal,
     :args
@@ -61,16 +61,16 @@
      {:type :literal, :value "white"}],
     :type :equal}},
   :command "ask",
-  :constraints #{},
+  :constraints #{:tc-23},
   :controllable false,
   :display-name "Ask",
-  :end-node :node-26,
+  :end-node :node-29,
   :htn-node :hem-23,
   :name "Ask((= :field1.:simple2 \"white\"))",
   :plantid "bsm1",
   :tpn-type :activity,
-  :uid :act-21},
- :act-25
+  :uid :act-24},
+ :act-28
  {:args
   [{:type :equal,
     :args
@@ -86,13 +86,13 @@
   :constraints #{},
   :controllable false,
   :display-name "Tell",
-  :end-node :node-30,
+  :end-node :node-33,
   :htn-node :hem-23,
   :name "Tell((= door :open))",
   :plantid "bsm1",
   :tpn-type :activity,
-  :uid :act-25},
- :act-29
+  :uid :act-28},
+ :act-32
  {:args [],
   :argsmap {},
   :command "initialize",
@@ -105,7 +105,7 @@
   :name "Initialize",
   :reward 0,
   :tpn-type :activity,
-  :uid :act-29},
+  :uid :act-32},
  :act-9
  {:args [:field1.:simple2],
   :argsmap {"x" :field1.:simple2},
@@ -114,7 +114,7 @@
   :controllable false,
   :cost 0,
   :display-name "One Arg Method",
-  :end-node :node-14,
+  :end-node :node-15,
   :htn-node :hem-23,
   :name "One Arg Method(:field1.:simple2)",
   :reward 0,
@@ -129,7 +129,7 @@
  :node-1
  {:activities #{},
   :constraints #{},
-  :incidence-set #{:act-29},
+  :incidence-set #{:act-32},
   :tpn-type :state,
   :uid :node-1},
  :node-10
@@ -140,38 +140,53 @@
   :incidence-set #{},
   :tpn-type :state,
   :uid :node-10},
- :node-14
- {:activities #{:act-13},
+ :node-15
+ {:activities #{:act-14},
   :constraints #{},
   :htn-node :hem-23,
   :incidence-set #{:act-9},
   :tpn-type :state,
-  :uid :node-14},
- :node-18
- {:activities #{:act-17},
+  :uid :node-15},
+ :node-20
+ {:activities #{:act-19},
   :constraints #{},
   :htn-node :hem-23,
-  :incidence-set #{:act-13},
+  :incidence-set #{:act-14},
   :tpn-type :state,
-  :uid :node-18},
- :node-22
- {:activities #{:act-21},
+  :uid :node-20},
+ :node-25
+ {:activities #{:act-24},
   :constraints #{},
   :htn-node :hem-23,
-  :incidence-set #{:act-17},
+  :incidence-set #{:act-19},
   :tpn-type :state,
-  :uid :node-22},
- :node-26
- {:activities #{:act-25},
+  :uid :node-25},
+ :node-29
+ {:activities #{:act-28},
   :constraints #{},
   :htn-node :hem-23,
-  :incidence-set #{:act-21},
+  :incidence-set #{:act-24},
   :tpn-type :state,
-  :uid :node-26},
- :node-30
- {:activities #{:act-29},
+  :uid :node-29},
+ :node-33
+ {:activities #{:act-32},
   :constraints #{},
   :htn-node :hem-23,
-  :incidence-set #{:act-25},
+  :incidence-set #{:act-28},
   :tpn-type :state,
-  :uid :node-30}}
+  :uid :node-33},
+ :tc-13
+ {:end-node :node-20,
+  :tpn-type :temporal-constraint,
+  :uid :tc-13,
+  :value [3 5]},
+ :tc-18
+ {:end-node :node-25,
+  :tpn-type :temporal-constraint,
+  :uid :tc-18,
+  :value [4 7]},
+ :tc-23
+ {:end-node :node-29,
+  :tpn-type :temporal-constraint,
+  :uid :tc-23,
+  :value [4 7]}}

--- a/test/pamela/IR/cannon.ir.edn
+++ b/test/pamela/IR/cannon.ir.edn
@@ -103,13 +103,6 @@
      [{:type :parallel,
        :body
        [{:type :whenever,
-         :body
-         [{:type :tell,
-           :condition
-           {:type :equal,
-            :args
-            [{:type :state-variable, :name all-clear}
-             {:type :literal, :value true}]}}],
          :condition
          {:type :equal,
           :args
@@ -117,25 +110,55 @@
             :pclass this,
             :field :box-f,
             :value :ball-in-motion}
-           {:type :literal, :value true}]}}
+           {:type :literal, :value true}]},
+         :body
+         [{:type :tell,
+           :condition
+           {:type :equal,
+            :args
+            [{:type :state-variable, :name all-clear}
+             {:type :literal, :value true}]}}]}
         {:type :whenever,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference-field,
+            :pclass this,
+            :field :cannon-f,
+            :value :ready}
+           {:type :literal, :value true}]},
          :body
          [{:type :unless,
+           :condition
+           {:type :equal,
+            :args
+            [{:type :field-reference-field,
+              :pclass this,
+              :field :cannon-f,
+              :value :ammunitions}
+             {:type :literal, :value 0}]},
            :body
            [{:type :try,
              :body
              [{:type :sequence,
                :body
                [{:type :assert,
-                 :body nil,
                  :condition
                  {:type :equal,
                   :args
                   [{:type :field-reference,
                     :pclass this,
                     :field :box-f}
-                   {:type :mode-reference, :pclass box, :mode :open}]}}
+                   {:type :mode-reference, :pclass box, :mode :open}]},
+                 :body nil}
                 {:type :maintain,
+                 :condition
+                 {:type :equal,
+                  :args
+                  [{:type :field-reference,
+                    :pclass this,
+                    :field :box-f}
+                   {:type :mode-reference, :pclass box, :mode :open}]},
                  :body
                  [{:type :sequence,
                    :body
@@ -146,19 +169,12 @@
                      :temporal-constraints
                      [{:type :bounds, :value [1 7]}]}
                     {:type :ask,
-                     :body nil,
                      :condition
                      {:type :equal,
                       :args
                       [{:type :state-variable, :name all-clear}
-                       {:type :literal, :value true}]}}]}],
-                 :condition
-                 {:type :equal,
-                  :args
-                  [{:type :field-reference,
-                    :pclass this,
-                    :field :box-f}
-                   {:type :mode-reference, :pclass box, :mode :open}]}}
+                       {:type :literal, :value true}]},
+                     :body nil}]}]}
                 {:type :plant-fn-field,
                  :field :box-f,
                  :method close-lid,
@@ -180,23 +196,8 @@
                  :body nil,
                  :temporal-constraints
                  [{:type :bounds, :value [30 30]}]}]}],
-             :temporal-constraints [{:type :bounds, :value [2 20]}]}],
-           :condition
-           {:type :equal,
-            :args
-            [{:type :field-reference-field,
-              :pclass this,
-              :field :cannon-f,
-              :value :ammunitions}
-             {:type :literal, :value 0}]}}],
-         :condition
-         {:type :equal,
-          :args
-          [{:type :field-reference-field,
-            :pclass this,
-            :field :cannon-f,
-            :value :ready}
-           {:type :literal, :value true}]}}],
+             :temporal-constraints
+             [{:type :bounds, :value [2 20]}]}]}]}],
        :temporal-constraints [{:type :bounds, :value [1 60]}]}],
      :controllable false,
      :cost 0,

--- a/test/pamela/IR/ir-test.ir.edn
+++ b/test/pamela/IR/ir-test.ir.edn
@@ -1,10 +1,4 @@
-{pwrvals
- {:args [],
-  :meta {:doc "Enum for power values", :version "0.2.0"},
-  :modes
-  {:high {:type :literal, :value true},
-   :none {:type :literal, :value true}},
-  :type :pclass},
+{all-clear {:type :state-variable},
  box
  {:args [],
   :fields
@@ -30,19 +24,7 @@
    :icon "box.svg",
    :version "0.0.1"},
   :methods
-  {open-lid
-   [{:args [],
-     :betweens [],
-     :body nil,
-     :controllable false,
-     :cost 0,
-     :display-name "Open Lid",
-     :post {:type :mode-reference, :pclass this, :mode :open},
-     :pre {:type :mode-reference, :pclass this, :mode :close},
-     :primitive true,
-     :reward 0,
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}],
-   close-lid
+  {close-lid
    [{:args [],
      :betweens [],
      :body nil,
@@ -55,6 +37,18 @@
      :primitive true,
      :reward 1000,
      :temporal-constraints [{:type :bounds, :value [123 456]}]}],
+   open-lid
+   [{:args [],
+     :betweens [],
+     :body nil,
+     :controllable false,
+     :cost 0,
+     :display-name "Open Lid",
+     :post {:type :mode-reference, :pclass this, :mode :open},
+     :pre {:type :mode-reference, :pclass this, :mode :close},
+     :primitive true,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}],
    reset
    [{:args [],
      :betweens [],
@@ -162,13 +156,6 @@
      [{:type :parallel,
        :body
        [{:type :whenever,
-         :body
-         [{:type :tell,
-           :condition
-           {:type :equal,
-            :args
-            [{:type :state-variable, :name all-clear}
-             {:type :state-variable, :name initial-state}]}}],
          :condition
          {:type :equal,
           :args
@@ -176,25 +163,55 @@
             :pclass this,
             :field :box-f,
             :value :ball-in-motion}
-           {:type :literal, :value true}]}}
+           {:type :literal, :value true}]},
+         :body
+         [{:type :tell,
+           :condition
+           {:type :equal,
+            :args
+            [{:type :state-variable, :name all-clear}
+             {:type :state-variable, :name initial-state}]}}]}
         {:type :whenever,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference-field,
+            :pclass this,
+            :field :cannon-f,
+            :value :ready}
+           {:type :literal, :value true}]},
          :body
          [{:type :unless,
+           :condition
+           {:type :equal,
+            :args
+            [{:type :field-reference-field,
+              :pclass this,
+              :field :cannon-f,
+              :value :ammunitions}
+             {:type :literal, :value 0}]},
            :body
            [{:type :try,
              :body
              [{:type :sequence,
                :body
                [{:type :assert,
-                 :body nil,
                  :condition
                  {:type :equal,
                   :args
                   [{:type :field-reference,
                     :pclass this,
                     :field :box-f}
-                   {:type :mode-reference, :pclass box, :mode :open}]}}
+                   {:type :mode-reference, :pclass box, :mode :open}]},
+                 :body nil}
                 {:type :maintain,
+                 :condition
+                 {:type :equal,
+                  :args
+                  [{:type :field-reference,
+                    :pclass this,
+                    :field :box-f}
+                   {:type :mode-reference, :pclass box, :mode :open}]},
                  :body
                  [{:type :sequence,
                    :body
@@ -205,26 +222,19 @@
                      :temporal-constraints
                      [{:type :bounds, :value [1 7]}]}
                     {:type :ask,
-                     :body
-                     [{:temporal-constraints
-                       [{:type :bounds, :value [200 300]}]}],
                      :condition
                      {:type :equal,
                       :args
                       [{:type :state-variable, :name all-clear}
-                       {:type :literal, :value true}]}}],
+                       {:type :literal, :value true}]},
+                     :body nil,
+                     :temporal-constraints
+                     [{:type :bounds, :value [200 300]}]}],
                    :label :my,
                    :temporal-constraints
                    [{:type :bounds, :value [98 101]}],
                    :cost<= 11,
-                   :reward>= 90}],
-                 :condition
-                 {:type :equal,
-                  :args
-                  [{:type :field-reference,
-                    :pclass this,
-                    :field :box-f}
-                   {:type :mode-reference, :pclass box, :mode :open}]}}
+                   :reward>= 90}]}
                 {:type :plant-fn-field,
                  :field :box-f,
                  :method close-lid,
@@ -272,23 +282,8 @@
                  :body nil,
                  :temporal-constraints
                  [{:type :bounds, :value [30 30]}]}]}],
-             :temporal-constraints [{:type :bounds, :value [2 20]}]}],
-           :condition
-           {:type :equal,
-            :args
-            [{:type :field-reference-field,
-              :pclass this,
-              :field :cannon-f,
-              :value :ammunitions}
-             {:type :literal, :value 0}]}}],
-         :condition
-         {:type :equal,
-          :args
-          [{:type :field-reference-field,
-            :pclass this,
-            :field :cannon-f,
-            :value :ready}
-           {:type :literal, :value true}]}}
+             :temporal-constraints
+             [{:type :bounds, :value [2 20]}]}]}]}
         {:type :sequence,
          :body
          [{:type :delay,
@@ -471,6 +466,12 @@
     :type :and}},
   :type :pclass},
  global-state {:type :state-variable},
- all-clear {:type :state-variable},
  initial-state {:type :state-variable},
+ pwrvals
+ {:args [],
+  :meta {:doc "Enum for power values", :version "0.2.0"},
+  :modes
+  {:high {:type :literal, :value true},
+   :none {:type :literal, :value true}},
+  :type :pclass},
  pamela/lvars {:lvars {"fred" :unset}, :type :lvars}}

--- a/test/pamela/IR/issue-122.ir.edn
+++ b/test/pamela/IR/issue-122.ir.edn
@@ -1,0 +1,77 @@
+{issue-122
+ {:args [],
+  :fields
+  {:value
+   {:access :private,
+    :initial {:type :literal, :value 122},
+    :observable false}},
+  :methods
+  {main
+   [{:args [],
+     :betweens [],
+     :body
+     [{:type :parallel,
+       :body
+       [{:type :ask,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 100}]},
+         :body nil,
+         :temporal-constraints [{:type :bounds, :value [0 1]}]}
+        {:type :assert,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 200}]},
+         :body nil,
+         :temporal-constraints [{:type :bounds, :value [2 3]}]}
+        {:type :maintain,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 300}]},
+         :body [{:type :delay, :body nil}],
+         :temporal-constraints [{:type :bounds, :value [4 5]}]}
+        {:type :tell,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 400}]}}
+        {:type :unless,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 500}]},
+         :body [{:type :delay, :body nil}],
+         :temporal-constraints [{:type :bounds, :value [6 7]}]}
+        {:type :when,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 600}]},
+         :body [{:type :delay, :body nil}],
+         :temporal-constraints [{:type :bounds, :value [8 9]}]}
+        {:type :whenever,
+         :condition
+         {:type :equal,
+          :args
+          [{:type :field-reference, :pclass this, :field :value}
+           {:type :literal, :value 700}]},
+         :body [{:type :delay, :body nil}],
+         :temporal-constraints [{:type :bounds, :value [10 11]}]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Main",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
+  :type :pclass}}

--- a/test/pamela/IR/statements.ir.edn
+++ b/test/pamela/IR/statements.ir.edn
@@ -12,55 +12,47 @@
   :methods
   {initialize
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive true,
      :betweens [],
+     :body nil,
+     :controllable false,
+     :cost 0,
      :display-name "Initialize",
      :post {:type :literal, :value true},
-     :cost 0,
-     :body nil}],
+     :pre {:type :literal, :value true},
+     :primitive true,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}],
    main
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Main",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :plant-fn-symbol,
        :name this,
        :method test-of-various-statements,
-       :args []}]}],
+       :args []}],
+     :controllable false,
+     :cost 0,
+     :display-name "Main",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}],
    one-arg-method
    [{:args [x],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive true,
      :betweens [],
+     :body nil,
+     :controllable false,
+     :cost 0,
      :display-name "One Arg Method",
      :post {:type :literal, :value true},
-     :cost 0,
-     :body nil}],
+     :pre {:type :literal, :value true},
+     :primitive true,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}],
    test-of-various-statements
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Test Of Various Statements",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :sequence,
        :body
@@ -69,24 +61,22 @@
          :method one-arg-method,
          :args [:field1.:simple2]}
         {:type :assert,
-         :body
-         [{:temporal-constraints [{:type :bounds, :value [3 5]}]}],
          :condition
          {:type :equal,
           :args
           [{:type :state-variable, :name foo}
-           {:type :literal, :value :illuminated}]}}
+           {:type :literal, :value :illuminated}]},
+         :body nil,
+         :temporal-constraints [{:type :bounds, :value [3 5]}]}
         {:type :ask,
-         :body
-         [{:temporal-constraints [{:type :bounds, :value [4 7]}]}],
          :condition
          {:type :equal,
           :args
           [{:type :state-variable, :name bar}
-           {:type :literal, :value :dead}]}}
+           {:type :literal, :value :dead}]},
+         :body nil,
+         :temporal-constraints [{:type :bounds, :value [4 7]}]}
         {:type :ask,
-         :body
-         [{:temporal-constraints [{:type :bounds, :value [4 7]}]}],
          :condition
          {:type :equal,
           :args
@@ -94,7 +84,9 @@
             :pclass this,
             :field :field1,
             :value :simple2}
-           {:type :literal, :value "white"}]}}
+           {:type :literal, :value "white"}]},
+         :body nil,
+         :temporal-constraints [{:type :bounds, :value [4 7]}]}
         {:type :tell,
          :condition
          {:type :equal,
@@ -104,7 +96,15 @@
         {:type :plant-fn-symbol,
          :name this,
          :method initialize,
-         :args []}]}]}]},
+         :args []}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Test Of Various Statements",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass},
  simple-pclass
  {:args [simple2-initial],
@@ -120,14 +120,14 @@
   :methods
   {simple-method
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive true,
      :betweens [],
+     :body nil,
+     :controllable false,
+     :cost 0,
      :display-name "Simple Method",
      :post {:type :literal, :value true},
-     :cost 0,
-     :body nil}]},
+     :pre {:type :literal, :value true},
+     :primitive true,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/issue-122.pamela
+++ b/test/pamela/issue-122.pamela
@@ -1,0 +1,31 @@
+;; Copyright © 2017 Dynamic Object Language Labs Inc.
+;;
+;; This software is licensed under the terms of the
+;; Apache License, Version 2.0 which can be found in
+;; the file LICENSE at the root of this distribution.
+
+;; Acknowledgement and Disclaimer:
+;; This material is based upon work supported by the Army Contracting
+;; and DARPA under contract No. W911NF-15-C-0005.
+;; Any opinions, findings and conclusions or recommendations expressed
+;; in this material are those of the author(s) and do necessarily reflect the
+;; views of the Army Contracting Command and DARPA.
+
+;; Issue #122 test
+
+(defpclass issue-122 []
+  :fields {:value 122}
+  :methods [(defpmethod main []
+              (parallel
+                (ask (= :value 100) :bounds [0 1])
+                (assert (= :value 200) :bounds [2 3])
+                (maintain (= :value 300) :bounds [4 5]
+                  (delay))
+                (tell (= :value 400))
+                (unless (= :value 500) :bounds [6 7]
+                  (delay))
+                (when (= :value 600) :bounds [8 9]
+                      (delay))
+                (whenever (= :value 700) :bounds [10 11]
+                  (delay))
+                ))])

--- a/test/pamela/regression/IR/ask-bounds.ir.edn
+++ b/test/pamela/regression/IR/ask-bounds.ir.edn
@@ -9,23 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :ask,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body nil,
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/regression/IR/assert-bounds.ir.edn
+++ b/test/pamela/regression/IR/assert-bounds.ir.edn
@@ -9,23 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :assert,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body nil,
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/regression/IR/maintain-bounds.ir.edn
+++ b/test/pamela/regression/IR/maintain-bounds.ir.edn
@@ -9,24 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :maintain,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}
-        {:type :delay, :body nil}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body [{:type :delay, :body nil}],
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/regression/IR/unless-bounds.ir.edn
+++ b/test/pamela/regression/IR/unless-bounds.ir.edn
@@ -9,24 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :unless,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}
-        {:type :delay, :body nil}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body [{:type :delay, :body nil}],
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/regression/IR/when-bounds.ir.edn
+++ b/test/pamela/regression/IR/when-bounds.ir.edn
@@ -9,24 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :when,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}
-        {:type :delay, :body nil}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body [{:type :delay, :body nil}],
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}

--- a/test/pamela/regression/IR/whenever-bounds.ir.edn
+++ b/test/pamela/regression/IR/whenever-bounds.ir.edn
@@ -9,24 +9,23 @@
   :methods
   {always-on
    [{:args [],
-     :pre {:type :literal, :value true},
-     :temporal-constraints [{:type :bounds, :value [0 :infinity]}],
-     :reward 0,
-     :controllable false,
-     :primitive false,
      :betweens [],
-     :display-name "Always On",
-     :post {:type :literal, :value true},
-     :cost 0,
      :body
      [{:type :whenever,
-       :body
-       [{:temporal-constraints [{:type :bounds, :value [1 100]}]}
-        {:type :delay, :body nil}],
        :condition
        {:type :equal,
         :args
         [{:type :field-reference, :pclass this, :field :a}
-         {:type :literal, :value 1.0}]}}],
-     :doc "ensure field :a is always 1.0"}]},
+         {:type :literal, :value 1.0}]},
+       :body [{:type :delay, :body nil}],
+       :temporal-constraints [{:type :bounds, :value [1 100]}]}],
+     :controllable false,
+     :cost 0,
+     :display-name "Always On",
+     :doc "ensure field :a is always 1.0",
+     :post {:type :literal, :value true},
+     :pre {:type :literal, :value true},
+     :primitive false,
+     :reward 0,
+     :temporal-constraints [{:type :bounds, :value [0 :infinity]}]}]},
   :type :pclass}}


### PR DESCRIPTION
Fixed statements include ask, assert, maintain, unless, when, whenever
(Closes #122)
Updated plan-schema dependency to 0.3.6

Signed-off-by: Tom Marble <tmarble@info9.net>