### PR TITLE
Added temporary "json-ir" file format to cli.clj and utils.clj to all…

### DIFF
--- a/src/pamela/cli.clj
+++ b/src/pamela/cli.clj
@@ -72,7 +72,7 @@
   [options]
   (let [{:keys [input output source json-ir]} options
         ir (parser/parse options)
-        file-format (if-not json-ir "edn-mixed" "json")]
+        file-format (if-not json-ir "edn-mixed" "json-ir")] ; +++ undo this when we have a combined JSON format for Pamela
     (if (:error ir)
       (do
         (log/errorf "unable to parse: %s\nerror: %s" input (with-out-str (pprint (:error ir))))
@@ -142,7 +142,7 @@
       (do
         (log/errorf "unable to parse: %s\nerror: %s" input (with-out-str (pprint (:error ir))))
         1)
-      (if-not (#{"edn" "json"} file-format)
+      (if-not (#{"edn" "json" "json-ir"} file-format) ;+++ remove json-ir when we have a single integrated json format
         (do
           (log/errorf "illegal file-format for htn: %s" file-format)
           1)

--- a/src/pamela/utils.clj
+++ b/src/pamela/utils.clj
@@ -80,7 +80,7 @@
                             (if (fs/absolute? filename)
                               (fs/file filename)
                               (fs/file (get-cwd) filename)))
-          data (if (= file-format "json") (encode-ir-tokens-as-strings data) data) ; Only for JSON files
+          data (if (= file-format "json-ir") (encode-ir-tokens-as-strings data) data) ; Only for JSON files
           data (if (map? data)
                  ;; (if (= file-format "edn-mixed")
                  ;;   (sort-mixed-map data)
@@ -90,7 +90,8 @@
           out (cond
                 (#{"edn" "edn-mixed"} file-format)
                 (with-out-str (pprint data))
-                (= file-format "json")
+                (or (= file-format "json")
+                    (= file-format "json-ir"))
                 (with-out-str (json/pprint data))
                 :else
                 data)]

--- a/src/pamela/utils.clj
+++ b/src/pamela/utils.clj
@@ -80,7 +80,7 @@
                             (if (fs/absolute? filename)
                               (fs/file filename)
                               (fs/file (get-cwd) filename)))
-          data (if (= file-format "json-ir") (encode-ir-tokens-as-strings data) data) ; Only for JSON files
+          data (if (= file-format "json-ir") (encode-ir-tokens-as-strings data) data) ; Only for JSON (IR) files
           data (if (map? data)
                  ;; (if (= file-format "edn-mixed")
                  ;;   (sort-mixed-map data)


### PR DESCRIPTION
"json-ir" file-format was added to distinguish json-ir from other uses of json until such time as we have a unified solution to json usage throughout pamela